### PR TITLE
修复UI issue on Firefox browser #6

### DIFF
--- a/src/static/css/swap.less
+++ b/src/static/css/swap.less
@@ -78,7 +78,7 @@
         font-weight: bold;
         color: var(--primary-text);
         line-height: 24px;
-        ;
+        width: 80%;/*解决单位超出范围BUG*/
       }
 
       .token-box {


### PR DESCRIPTION
增加一个宽度限制。不论多少都不影响，文本框后面内容将自适应宽度。 测试 EDGE(版本 89.0.774.45), CHROME(版本 89.0.4389.82),FIREFOX(86.0).